### PR TITLE
prevent NPE in TcpSyslogMessageSender.close()

### DIFF
--- a/src/main/java/com/cloudbees/syslog/sender/TcpSyslogMessageSender.java
+++ b/src/main/java/com/cloudbees/syslog/sender/TcpSyslogMessageSender.java
@@ -288,6 +288,8 @@ public class TcpSyslogMessageSender extends AbstractSyslogMessageSender implemen
 
     @Override
     public void close() throws IOException {
-        this.socket.close();
+        if (socket != null) {
+            this.socket.close();
+        }
     }
 }


### PR DESCRIPTION
TcpSyslogMessageSender.close() method is public, and can be called from outside.
However, the socket is private and it's value can't be verified.
Since trying to close a null socket makes no sense, wrapping it with a null check is requested.