### PR TITLE
Adding logger statements if we get exception while closing socket connection

### DIFF
--- a/src/main/java/com/cloudbees/syslog/sender/TcpSyslogMessageSender.java
+++ b/src/main/java/com/cloudbees/syslog/sender/TcpSyslogMessageSender.java
@@ -112,11 +112,11 @@ public class TcpSyslogMessageSender extends AbstractSyslogMessageSender implemen
             }
             if (lastException != null) {
                 sendErrorCounter.incrementAndGet();
-                if (lastException instanceof IOException) {
-                    throw (IOException) lastException;
-                } else if (lastException instanceof RuntimeException) {
-                    throw (RuntimeException) lastException;
-                }
+            }
+            if (lastException instanceof IOException) {
+                throw (IOException) lastException;
+            } else if (lastException instanceof RuntimeException) {
+                throw (RuntimeException) lastException;
             }
         } finally {
             sendDurationInNanosCounter.addAndGet(System.nanoTime() - nanosBefore);

--- a/src/main/java/com/cloudbees/syslog/util/IoUtils.java
+++ b/src/main/java/com/cloudbees/syslog/util/IoUtils.java
@@ -24,6 +24,8 @@ import java.net.Socket;
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
 public class IoUtils {
+    private static final InternalLogger logger = InternalLogger.getLogger(IoUtils.class);
+
     private IoUtils() {
 
     }
@@ -34,6 +36,7 @@ public class IoUtils {
                 socket.close();
             }
         } catch (Exception e) {
+            logger.warn("Exception while closing the socket "+socket, e);
         }
     }
 
@@ -48,7 +51,7 @@ public class IoUtils {
             try {
                 writer.close();
             } catch (IOException e) {
-
+                logger.warn("Exception while closing writer for socket "+socket, e);
             }
         }
         closeQuietly(socket);

--- a/src/test/java/com/cloudbees/syslog/util/IoUtilsTest.java
+++ b/src/test/java/com/cloudbees/syslog/util/IoUtilsTest.java
@@ -1,0 +1,53 @@
+package com.cloudbees.syslog.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.Socket;
+
+import org.junit.Test;
+
+public class IoUtilsTest {
+
+	@Test
+	public void testCloseQuietlyWithSocket() {
+		Socket socket = new Socket();
+		IoUtils.closeQuietly(socket);
+		assertThat(socket.isClosed(), is(true));
+
+	}
+
+	@Test
+	public void testCloseQuietlyWithNullSocket() {
+		IoUtils.closeQuietly(null);
+		// No exception should be thrown for null socket
+	}
+
+	@Test
+	public void testCloseQuietlyWithSocketAndWriter() {
+		Socket socket = new Socket();
+		Writer writer = new OutputStreamWriter(new ByteArrayOutputStream());
+
+		IoUtils.closeQuietly(socket, writer);
+		assertThat(socket.isClosed(), is(true));
+		// Since we don't mock the writer, we can't directly verify if it's closed
+		// However, we know that the method should execute without throwing exceptions
+
+	}
+
+	@Test
+	public void testCloseQuietlyWithNullSocketAndNullWriter() {
+		IoUtils.closeQuietly(null, null);
+		// No exception should be thrown for null socket and null writer
+	}
+
+	@Test
+	public void testCloseQuietlyWithSocketAndNullWriter() {
+		Socket socket = new Socket();
+		IoUtils.closeQuietly(socket, null);
+		assertThat(socket.isClosed(), is(true));
+
+	}
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Log statements are really required in catch block if we get any exception while closing socket.
Added warning statements with required info and add Junit file

Tested using Junits and ensured no impact on functionality.

https://github.com/jenkinsci/syslog-java-client/issues/137

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ X] Link to relevant issues in GitHub or Jira
- [X ] Link to relevant pull requests, esp. upstream and downstream changes
- [X ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
